### PR TITLE
Replace assets with new impressive samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Markdown to Slide creator Logo](images/markdown-to-slide-creator-logo.png)
+
 # Markdown to Slide creator
 
 [![CI](https://github.com/sun-flat-yamada/markdown-to-slide-creator/actions/workflows/ci.yml/badge.svg)](https://github.com/sun-flat-yamada/markdown-to-slide-creator/actions/workflows/ci.yml)

--- a/assets/corp_logo_mdsc.png
+++ b/assets/corp_logo_mdsc.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06b1640adf129d9039d41426d4115f75dba8f2ee16e12b8eebc320a52771eb2a
+size 25720

--- a/assets/cover_sample_wave.png
+++ b/assets/cover_sample_wave.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:073bfda33ff1d5efc49321c5fb81e2e9223ac383e32b6486f96e9ad598161094
+size 45506

--- a/corporate-config.yaml
+++ b/corporate-config.yaml
@@ -39,7 +39,7 @@ colors:
 
 # ロゴ
 logo:
-  path: './assets/logo.svg'
+  path: './assets/corp_logo_mdsc.png'
   width: '150px'
   position: 'footer-right'
 
@@ -86,7 +86,7 @@ special_slides:
     show_accent_line: true
     accent_line_color: '{{gradient:cover-line}}'
     layout: 'image-right'
-    image: './assets/cover.svg'
+    image: './assets/cover_sample_wave.png'
     show_logo: true
     logo_position: 'bottom-right'
 
@@ -114,4 +114,4 @@ auto_structure:
 
 # AI プロンプト
 ai_prompt:
-  path: './prompts/slide-convert.md'
+  path: './.agent/skills/create-slide-deck/SKILL.md'

--- a/images/markdown-to-slide-creator-logo.png
+++ b/images/markdown-to-slide-creator-logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44602be9818e19e4f1cfd44f82f25979c31d7042a007b270f63b644f75b27ffb
+size 13109

--- a/tests/preprocessor.test.ts
+++ b/tests/preprocessor.test.ts
@@ -46,9 +46,9 @@ const testConfig: CorporateConfig = {
   },
   margin: { top: '60px', bottom: '50px', left: '50px', right: '50px' },
   special_slides: {
-    cover: { background: '#FFF' },
-    section_divider: { background: '#FFF' },
-    end: { background: '#FFF', show_logo: false, show_tagline: false },
+    cover: { background: '#FFF', layout: 'default' },
+    section_divider: { background: '#FFF', layout: 'default' },
+    end: { background: '#FFF', show_logo: false, show_tagline: false, layout: 'default' },
   },
   auto_structure: {
     enabled: true,
@@ -56,7 +56,7 @@ const testConfig: CorporateConfig = {
     auto_cover: true,
     auto_end: true,
   },
-  ai_prompt: { path: './prompts/slide-convert.md' },
+  ai_prompt: { path: './.agent/skills/create-slide-deck/SKILL.md' },
 };
 
 describe('preprocessMarkdown', () => {
@@ -115,7 +115,7 @@ describe('preprocessMarkdown', () => {
     const logoConfig: CorporateConfig = {
       ...testConfig,
       logo: {
-        path: './assets/logo.svg',
+        path: './assets/corp_logo_mdsc.png',
         width: '120px',
         position: 'footer-right',
       },
@@ -128,17 +128,17 @@ describe('preprocessMarkdown', () => {
     const result = preprocessMarkdown(md, logoConfig);
 
     expect(result.markdown).toContain(
-      '<img src="./assets/logo.svg" alt="logo" class="cover-logo" style="width: 120px;">',
+      '<img src="./assets/corp_logo_mdsc.png" alt="logo" class="cover-logo" style="width: 120px;">',
     );
     expect(result.markdown).toContain(
-      '<img src="./assets/logo.svg" alt="logo" class="end-logo" style="width: 120px;">',
+      '<img src="./assets/corp_logo_mdsc.png" alt="logo" class="end-logo" style="width: 120px;">',
     );
   });
 
   it('should generate cover with image-right layout', () => {
     const layoutConfig: CorporateConfig = JSON.parse(JSON.stringify(testConfig));
     layoutConfig.special_slides.cover.layout = 'image-right';
-    layoutConfig.special_slides.cover.image = '/path/to/image.jpg';
+    layoutConfig.special_slides.cover.image = './assets/cover_sample_wave.png';
 
     const md = `# Title\n## Subtitle`;
     const result = preprocessMarkdown(md, layoutConfig);
@@ -146,7 +146,7 @@ describe('preprocessMarkdown', () => {
     expect(result.markdown).toContain('<!-- _class: cover-image-right -->');
     expect(result.markdown).toContain('<div class="cover-content">');
     expect(result.markdown).toContain(
-      '<div class="cover-image-container"><img src="/path/to/image.jpg" class="cover-image" /></div>',
+      '<div class="cover-image-container"><img src="./assets/cover_sample_wave.png" class="cover-image" /></div>',
     );
   });
 });


### PR DESCRIPTION
Closes #14. Replaces placeholder SVG assets with high-quality PNG images and updates configuration/tests.